### PR TITLE
Add runtime and build image info to `docker:go`

### DIFF
--- a/builder-library/docker-go.md
+++ b/builder-library/docker-go.md
@@ -154,7 +154,7 @@ To add additional directives or customize your build further, add a section to y
 
 ```text
 [builders."docker:go"]
-skip_runtime_image  = false
+skip_runtime_image = true
 
 [builders."docker:go".dockerfile_extensions]
 pre_mod_download    = "RUN echo 'at pre_mod_download'"
@@ -165,6 +165,14 @@ pre_build           = "RUN echo 'at pre_build'"
 post_build          = "RUN echo 'at post_build'"
 pre_runtime_copy    = "RUN echo 'at pre_runtime_copy'"
 post_runtime_copy   = "RUN echo 'at post_runtime_copy'"
+```
+
+This example changes the build base image and enables the Go build cache:
+
+```
+[builders."docker:go"]
+build_base_image = "golang:1.14.4-buster"
+enable_go_build_cache = true
 ```
 
 ## Learn More

--- a/builder-library/docker-go.md
+++ b/builder-library/docker-go.md
@@ -37,22 +37,58 @@ If you want to just provide your own Dockerfile, use the `docker:generic` builde
 This feature is best explained by showing how it works. This is the default Dockerfile the `docker:go` builder will use to build plans. Notice that this is a go template. The template has a few points where customizations can be added.
 
 ```text
-ARG GO_VERSION=1.14.2
+ARG BUILD_BASE_IMAGE
+
+# This Dockerfile performs a multi-stage build and RUNTIME_IMAGE is the image
+# onto which to copy the resulting binary.
+#
+# Picking a different runtime base image from the build image allows us to
+# slim down the deployable considerably.
+#
+# The user can override the runtime image by passing in the appropriate builder
+# configuration option.
 ARG RUNTIME_IMAGE=busybox:1.31.1-glibc
-FROM golang:${GO_VERSION}-buster AS builder
+
+#:::
+#::: BUILD CONTAINER
+#:::
+FROM ${BUILD_BASE_IMAGE} AS builder
+
+# PLAN_DIR is the location containing the plan source inside the container.
+ENV PLAN_DIR /plan
+
+# SDK_DIR is the location containing the (optional) sdk source inside the container.
+ENV SDK_DIR /sdk
+
+# Delete any prior artifacts, if this is a cached image.
+RUN rm -rf ${PLAN_DIR} ${SDK_DIR} /testground_dep_list
+
+# TESTPLAN_EXEC_PKG is the executable package of the testplan to build.
+# The image will build that package only.
 ARG TESTPLAN_EXEC_PKG="."
+
+# GO_PROXY is the go proxy that will be used, or direct by default.
 ARG GO_PROXY=direct
+
+# BUILD_TAGS is either nothing, or when expanded, it expands to "-tags <comma-separated build tags>"
 ARG BUILD_TAGS
+
+# TESTPLAN_EXEC_PKG is the executable package within this test plan we want to build.
 ENV TESTPLAN_EXEC_PKG ${TESTPLAN_EXEC_PKG}
-ENV PLAN_DIR /plan/
-COPY /plan/go.mod ${PLAN_DIR}
+
+# We explicitly set GOCACHE under the /go directory for more tidiness.
+ENV GOCACHE /go/cache
+
+{{.DockerfileExtensions.PreModDownload}}
+
+# Copy only go.mod files and download deps, in order to leverage Docker caching.
+COPY /plan/go.mod ${PLAN_DIR}/go.mod
 
 {{if .WithSDK}}
 COPY /sdk/go.mod /sdk/go.mod
 {{end}}
 
-{{.DockerfileExtensions.PreModDownload}}
-
+# Download deps.
 RUN echo "Using go proxy: ${GO_PROXY}" \
     && cd ${PLAN_DIR} \
     && go env -w GOPROXY="${GO_PROXY}" \
@@ -62,6 +98,7 @@ RUN echo "Using go proxy: ${GO_PROXY}" \
 
 {{.DockerfileExtensions.PreSourceCopy}}
 
+# Now copy the rest of the source and run the build.
 COPY . /
 
 {{.DockerfileExtensions.PostSourceCopy}}
@@ -70,7 +107,7 @@ COPY . /
 
 RUN cd ${PLAN_DIR} \
     && go env -w GOPROXY="${GO_PROXY}" \
-    && GOOS=linux GOARCH=amd64 go build -o testplan ${BUILD_TAGS} ${TESTPLAN_EXEC_PKG}
+    && GOOS=linux GOARCH=amd64 go build -o ${PLAN_DIR}/testplan.bin ${BUILD_TAGS} ${TESTPLAN_EXEC_PKG}
 
 {{.DockerfileExtensions.PostBuild}}
 
@@ -78,24 +115,47 @@ RUN cd ${PLAN_DIR} \
 RUN cd ${PLAN_DIR} \
   && go list -m all > /testground_dep_list
 
+#:::
+#::: (OPTIONAL) RUNTIME CONTAINER
+#:::
 
-FROM ${RUNTIME_IMAGE} AS binary
+{{ if not .SkipRuntimeImage }}
+
+## The 'AS runtime' token is used to parse Docker stdout to extract the build image ID to cache.
+FROM ${RUNTIME_IMAGE} AS runtime
+
+# PLAN_DIR is the location containing the plan source inside the build container.
+ENV PLAN_DIR /plan
 
 {{.DockerfileExtensions.PreRuntimeCopy}}
 
 COPY --from=builder /testground_dep_list /
-COPY --from=builder /plan/testplan /
+COPY --from=builder ${PLAN_DIR}/testplan.bin /testplan
 
 {{.DockerfileExtensions.PostRuntimeCopy}}
 
+{{ else }}
+
+## The 'AS runtime' token is used to parse Docker stdout to extract the build image ID to cache.
+FROM builder AS runtime
+
+# PLAN_DIR is the location containing the plan source inside the build container.
+ENV PLAN_DIR /plan
+
+RUN mv ${PLAN_DIR}/testplan.bin /testplan
+
+{{ end }}
+
 EXPOSE 6060
 ENTRYPOINT [ "/testplan"]
-
 ```
 
-To add additional directives, add a section to your plan's `manifest.toml`. This example will add echo statements to each of the templated sections.
+To add additional directives or customize your build further, add a section to your plan's `manifest.toml`. This example will add echo statements to each of the templated sections and turn off the runtime image:
 
 ```text
+[builders."docker:go"]
+skip_runtime_image  = false
+
 [builders."docker:go".dockerfile_extensions]
 pre_mod_download    = "RUN echo 'at pre_mod_download'"
 post_mod_download   = "RUN echo 'at post_mod_download'"

--- a/builder-library/docker-go.md
+++ b/builder-library/docker-go.md
@@ -171,7 +171,7 @@ This example changes the build base image and enables the Go build cache:
 
 ```
 [builders."docker:go"]
-build_base_image = "golang:1.14.4-buster"
+build_base_image      = "golang:1.14.4-buster"
 enable_go_build_cache = true
 ```
 


### PR DESCRIPTION
Done in this PR:

- [x] Updates the Dockerfile template.
- [x] Adds a tiny bit of information for the `skip_runtime_image` option (testground/testground#1078)
- [x] Adds custom build base image (testground/testground#1081)

Please also check out:

- https://github.com/testground/testground/pull/1109

---

As of a side note, I don't have permissions on Testground gitbook.