### PR TITLE
Update parameters-and-testcases

### DIFF
--- a/writing-test-plans/communication-between-instances.md
+++ b/writing-test-plans/communication-between-instances.md
@@ -8,7 +8,7 @@ Lets create a plan in which one of the plans produces a `struct` which is re-con
 
 ### Setting up the`topic`
 
-`Transferrable` is the value type we will be transferring. 
+`Transferrable` is the value type we will be transferring.
 
 ```go
 type Transferrable struct {
@@ -30,7 +30,7 @@ To write to a topic, create a bounded client and use it to publish to the topic 
 
 ```go
 	ctx := context.Background()
-	
+
 	client := sync.MustBoundClient(ctx, runenv)
 	defer client.Close()
 
@@ -43,7 +43,7 @@ Subscribe to the topic we created earlier and set up a channel to receive the va
 
 ```go
 	tch := make(chan *Transferrable)
-	
+
 	_, err = client.Subscribe(ctx, st, tch)
 	if err != nil {
 		panic(err)
@@ -65,6 +65,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/testground/sdk-go/run"
 	"github.com/testground/sdk-go/runtime"
 	"github.com/testground/sdk-go/sync"
 )
@@ -97,16 +98,16 @@ func (t *Transferrable) String() string {
 }
 
 func main() {
-	runtime.Invoke(run)
+	run.Invoke(runf)
 }
 
-func run(runenv *runtime.RunEnv) error {
+func runf(runenv *runtime.RunEnv) error {
 	rand.Seed(time.Now().UnixNano())
 
 	ctx := context.Background()
 	client := sync.MustBoundClient(ctx, runenv)
 	defer client.Close()
-	
+
 	st := sync.NewTopic("transfer-key", &Transferrable{})
 
 	// Configure the test
@@ -135,7 +136,7 @@ func run(runenv *runtime.RunEnv) error {
 }
 ```
 
-Run with multiple instances: 
+Run with multiple instances:
 
 ```text
 $ testground run single -p quickstart -t quickstart -b exec:go -r local:exec -i 4
@@ -144,4 +145,3 @@ $ testground run single -p quickstart -t quickstart -b exec:go -r local:exec -i 
 {% hint style="info" %}
 Notice that instances is set to 4. Four instances will run at the same time.
 {% endhint %}
-

--- a/writing-test-plans/paramaters-and-testcases.md
+++ b/writing-test-plans/paramaters-and-testcases.md
@@ -53,31 +53,32 @@ As you can see, a test plan a simple executable that conforms to the [simple Tes
 package main
 
 import (
+  "github.com/ipfs/testground/sdk/run"
 	"github.com/ipfs/testground/sdk/runtime"
 )
 
 func main() {
-	runtime.InvokeMap(map[string]runtime.TestCaseFn{
-		"bigbrain": 	run,
-		"smallbrain": run,
+	run.InvokeMap(map[string]interface{}{
+		"bigbrain": 	runf,
+		"smallbrain": runf,
 	})
 }
 
-func run(runenv *runtime.RunEnv) error {
+func runf(runenv *runtime.RunEnv) error {
   var (
     num 		= runenv.IntParam("num")
   	word 		= runenv.StringParam("word")
   	feature = runenv.BooleanParam("feature")
   )
-  
+
 	runenv.RecordMessage("I am a %s test case.", runenv.TestCase)
 	runenv.RecordMessage("I store my files on %d servers.", num)
 	runenv.RecordMessage("I %s run tests on my P2P code.", word)
-	
+
 	if feature {
 		runenv.RecordMessage("I use IPFS!")
 	}
-	
+
 	return nil
 }
 ```
@@ -96,4 +97,3 @@ $ testground run single --plan quickstart \
 {% hint style="info" %}
 Try using different runners. This command executes the plan with the `local:exec` runner and `exec:go`builder, but it works just as well with the `local:docker` runner or the Kubernetes `cluster:k8s`runner \(for which you will need to use the  `docker:go` builder!
 {% endhint %}
-


### PR DESCRIPTION
The original piece of code for main.go does throw the following error, when executed as advised in the documentation.

```
# github.com/your/module/name
./main.go:12:5: undefined: "github.com/testground/sdk-go/runtime".InvokeMap
./main.go:12:34: undefined: "github.com/testground/sdk-go/runtime".TestCaseFn
```

The following screenshot shows the full error.

<img width="807" alt="fullerror" src="https://user-images.githubusercontent.com/33319680/116207954-b1f06780-a740-11eb-9315-2e5206f8ad74.png">

The changed code fixes this problem by importing run from the Go SDK. However, because run is used the function run has to be renamed to runf.
