### PR TITLE
doc: add missing references to `docker:generic`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ A test plan is a blackbox with a formal contract. Testground promises to inject 
 
 For running test plans written in different languages, targeted for different runtimes, and levels of scale:
 
-* `exec:go` and `docker:go` builders: compile test plans written in Go into executables or containers.
+* `exec:go` and `docker:go`, `docker:generic` builders: compile test plans into executables or containers.
 * `local:exec`, `local:docker`, `cluster:k8s` runners: run executables or containers locally \(suitable for 2-300 instances\), or in a Kubernetes cloud environment \(300-10k instances\).
 
 > Got some spare cycles and would like to add support for writing test plans Rust, Python or X? It's easy! Open an issue, and the community will guide you!

--- a/concepts-and-architecture/test-plans-and-test-cases/README.md
+++ b/concepts-and-architecture/test-plans-and-test-cases/README.md
@@ -64,6 +64,7 @@ Language, library choices and testing methodology must be opaque to the test inf
 \*\*\*\*
 
 Triggered by GitHub automation, manual action, or a schedule \(e.g. nightly\), the test pipeline will:
+* `exec:go` and `docker:go`, `docker:generic` builders: compile test plans into executables or containers.
 
 1. Check out a specific commit of go-ipfs and js-ipfs \(although our immediate priority is go-ipfs\). We call these **test targets**.
 2. Build it if necessary.

--- a/concepts-and-architecture/test-structure.md
+++ b/concepts-and-architecture/test-structure.md
@@ -11,10 +11,11 @@ Each test plan is a world of its own. ****In other words, ****test plans are _op
 {% hint style="info" %}
 Testground does not care what the test plan actually does, the language it's written in, nor the runtime it targets. As long as the source code is accessible, and a builder exists to compile that code into a runnable artifact, such as an executable or a Docker image, you're good to go 🚀 
 
-At the time of writing, Testground offers two builders:
+At the time of writing, Testground offers three builders:
 
 * **`exec:go`**compiles a Go test plan into a platform executable using the system Go installation.
 * **`docker:go`** compiles a Go test plan into a Docker image.
+* **`docker:generic`** compiles a generic test plan provided via Dockerfile into a Docker image.
 {% endhint %}
 
 ## The test plan &lt;&gt; Testground contract


### PR DESCRIPTION
Addresses https://github.com/testground/testground/issues/1519