### PR TITLE
feat: add community page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,5 +1,6 @@
 * Table of contents
   * [What is Testground?](README.md)
+    * [Community](community.md)
   * [Concepts and architecture](concepts-and-architecture/README.md)
     * [Test plans and test cases](concepts-and-architecture/test-structure.md)
     * [Daemon and client](concepts-and-architecture/daemon-and-client.md)

--- a/community.md
+++ b/community.md
@@ -8,7 +8,7 @@ No matter your area of specialty or level of expertise, there are many ways to c
 
 ## Chat
 
-In general, our Testground channels are bridged to Discord and Matrix. As a result, you can usually use your preferred chat application to engage with the community.
+Our Testground Slack channel is bridged to Discord and Matrix. As a result, you can usually use your preferred chat application to engage with the community.
 
 ### Discord
 

--- a/community.md
+++ b/community.md
@@ -1,0 +1,26 @@
+# Community
+
+Testground is home to a vibrant, diverse community of contributors and organisations from all over the globe! Here's how to get help, support, or just hang out with other folks who are helping to build the platform.
+
+## Ways to contribute
+
+No matter your area of specialty or level of expertise, there are many ways to contribute to Testground and make a real difference in the project. Join us on [github][github] and check out [good first issues][good-first-issues]
+
+## Chat
+
+In general, our Testground channels are bridged to Discord and Matrix. As a result, you can usually use your preferred chat application to engage with the community.
+
+### Discord
+
+Join the [IPFS Discord server](https://discord.gg/ipfs) and join the #testground-dev channel! [Server documentation can be found on Notion](https://pl-strflt.notion.site/IPFS-Discord-Server-Documentation-85bbc451303a473bbf6846b01610e3c1).
+
+### Matrix
+
+Join the [Matrix space](https://matrix.to/#/#ipfs-space:ipfs.io) and join the #testground-dev channel. [Homeserver documentation is available on Notion](https://pl-strflt.notion.site/IPFS-Matrix-Homeserver-Documentation-31481e76843547b7ab5160a87eed2b9f).
+
+### Slack
+
+Join [Filecoin slack](https://filecoin.io/slack) and join the #testground-dev channel. The [Filecoin Slack workspace user guide is available on Notion](https://pl-strflt.notion.site/Filecoin-Slack-User-Guide-29072679986b4ccb8ad7b091097dd770).
+
+[github]: https://github.com/testground/testground
+[good-first-issues]: https://github.com/testground/testground/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22


### PR DESCRIPTION
Add a basic community page, which we can link to in our Testground Newsletter for 2022.

heavily inspired by https://docs.ipfs.tech/community/ and https://docs.ipfs.tech/community/chat/