### PR TITLE
Fix broken link

### DIFF
--- a/concepts-and-architecture/test-structure.md
+++ b/concepts-and-architecture/test-structure.md
@@ -46,7 +46,7 @@ What's important is that **the test plans source is available to the Testground 
 
 !> Please note that `$TESTGROUND_HOME`is not the same place where you clone the Testground [git repository](https://github.com/testground/testground).
 
-The Testground client CLI offers a series of simple commands to manage test plan sources. Refer to the [Managing test plans](../managing-test-plans.md) section for more information.
+The Testground client CLI offers a series of simple commands to manage test plan sources. Refer to the [Managing test plans](managing-test-plans.md) section for more information.
 
 ## Test cases
 


### PR DESCRIPTION
The [Managing test plans](https://docs.testground.ai/master/#/../managing-test-plans) link leads to a 404. Removing `../` from the url leads to the correct [page](https://docs.testground.ai/master/#/managing-test-plans).